### PR TITLE
ci: different profiles for different operating periods

### DIFF
--- a/docs/powergim.md
+++ b/docs/powergim.md
@@ -251,6 +251,7 @@ parameters:
     operation_maintenance_rate: 0.05
     CO2_price: 0
     load_shed_penalty: 10000 # very high value of lost load (loadshedding penalty)
+    profiles_period_suffix: False
 ```
 
 Most of the parametes in the  ```nodetype```, ```branchtype``` and ```gentype```
@@ -269,6 +270,7 @@ Parameters specified in the ```parameters``` block are:
   relative to the investment cost
 * CO2_price = costs for CO2 emissions (EUR/kgCO2)
 * load_shed_penalty = penalty cost for load shedding (demand not supplied) (EUR/MWh)
+* profiles_period_suffix = True/False specifying whether to use different profiles for each operating period, with a `_<period>` suffix to the profile name
 
 ## Analysis of results
 

--- a/src/powergim/investment_model.py
+++ b/src/powergim/investment_model.py
@@ -159,6 +159,8 @@ class SipModel(pyo.ConcreteModel):
         # load shedding
         def bounds_load_shed(model, consumer, period, time):
             ref = self.grid_data.consumer.loc[consumer, "demand_ref"]
+            if self.parameters["profiles_period_suffix"]:
+                ref = f"{ref}_{period}"
             profile = self.grid_data.profiles.loc[time, ref]
             demand_avg = self.grid_data.consumer.loc[consumer, "demand_avg"]
             ub = max(0, demand_avg * profile)
@@ -291,6 +293,8 @@ class SipModel(pyo.ConcreteModel):
             cap = cap_existing + cap_new
             gentype = self.grid_data.generator.loc[gen, "type"]
             profile_ref = self.grid_data.generator.loc[gen, "inflow_ref"]
+            if self.parameters["profiles_period_suffix"]:
+                profile_ref = f"{profile_ref}_{period}"
             profile_fac = self.grid_data.generator.loc[gen, "inflow_fac"]
             profile_value = self.grid_data.profiles.loc[t, profile_ref] * profile_fac
             allow_curtailment = self.gentypes[gentype]["allow_curtailment"]
@@ -398,6 +402,8 @@ class SipModel(pyo.ConcreteModel):
                 if node_load == node:
                     dem_avg = self.grid_data.consumer.loc[cons, "demand_avg"]
                     dem_profile_ref = self.grid_data.consumer.loc[cons, "demand_ref"]
+                    if self.parameters["profiles_period_suffix"]:
+                         dem_profile_ref = f"{dem_profile_ref}_{period}"
                     profile = self.grid_data.profiles.loc[t, dem_profile_ref]
                     flow_into_node += -dem_avg * profile
 
@@ -524,6 +530,8 @@ class SipModel(pyo.ConcreteModel):
         for gen in self.s_gen:
             fuelcost = self.grid_data.generator.loc[gen, "fuelcost"]
             cost_profile_ref = self.grid_data.generator.loc[gen, "fuelcost_ref"]
+            if self.parameters["profiles_period_suffix"]:
+                cost_profile_ref = f"{cost_profile_ref}_{period}"
             cost_profile = self.grid_data.profiles[cost_profile_ref]
             gentype = self.grid_data.generator.loc[gen, "type"]
             emission_rate = self.gentypes[gentype]["CO2"]

--- a/src/powergim/testcases.py
+++ b/src/powergim/testcases.py
@@ -125,6 +125,7 @@ def create_case(investment_years, number_nodes, number_timesteps, base_MW=200):
             "operation_maintenance_rate": 0.05,
             "CO2_price": 0,
             "load_shed_penalty": 10000,
+            "profiles_period_suffix": False,
         },
     }
 
@@ -264,6 +265,7 @@ def create_case_star(investment_years, number_nodes, number_timesteps, base_MW=2
             "operation_maintenance_rate": 0.05,
             "CO2_price": 0,
             "load_shed_penalty": 10000,
+            "profiles_period_suffix": False,
         },
     }
 

--- a/tests/stochastic/data/parameters_stoch.yaml
+++ b/tests/stochastic/data/parameters_stoch.yaml
@@ -74,3 +74,5 @@ parameters:
     operation_maintenance_rate: 0.05
     CO2_price: 0
     load_shed_penalty: 10000 # very high value of lost load (loadshedding penalty)
+    profiles_period_suffix: False # Use same profiles for all operating periods
+    

--- a/tests/test_data/parameters.yaml
+++ b/tests/test_data/parameters.yaml
@@ -74,3 +74,4 @@ parameters:
     operation_maintenance_rate: 0.05
     CO2_price: 0
     load_shed_penalty: 10000 # very high value of lost load (loadshedding penalty)
+    profiles_period_suffix: False # Use same profiles for all operating periods


### PR DESCRIPTION
Add option to specify different time-series profiles for different operating periods

Closes #4 

BREAKING
- Requires a new parameter in input (yaml) file