### PR TITLE
make cutailment per generator option

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "powergim"
-version = "0.3"
+version = "0.3.1"
 description = "Power Grid Investment Module (PowerGIM)"
 authors = ["Harald G Svendsen <harald.svendsen@sintef.no>"]
 license = "MIT License (http://opensource.org/licenses/MIT)"

--- a/src/powergim/grid_data.py
+++ b/src/powergim/grid_data.py
@@ -49,6 +49,7 @@ class GridData(object):
                 **{f"capacity_{p}": None for p in self.investment_years},
                 **{f"expand_{p}": None for p in self.investment_years},
                 "pmin": None,
+                "allow_curtailment": None,
                 "p_maxNew": -1,
                 "cost_scaling": 1,
                 "fuelcost": None,

--- a/src/powergim/investment_model.py
+++ b/src/powergim/investment_model.py
@@ -292,13 +292,12 @@ class SipModel(pyo.ConcreteModel):
                 if self.grid_data.generator.loc[gen, f"expand_{p}"] == 1:
                     cap_new += self.v_gen_new_capacity[gen, p]
             cap = cap_existing + cap_new
-            gentype = self.grid_data.generator.loc[gen, "type"]
             profile_ref = self.grid_data.generator.loc[gen, "inflow_ref"]
             if self.parameters["profiles_period_suffix"]:
                 profile_ref = f"{profile_ref}_{period}"
             profile_fac = self.grid_data.generator.loc[gen, "inflow_fac"]
             profile_value = self.grid_data.profiles.loc[t, profile_ref] * profile_fac
-            allow_curtailment = self.gentypes[gentype]["allow_curtailment"]
+            allow_curtailment = self.grid_data.generator.loc[gen, "allow_curtailment"]
             if allow_curtailment:
                 expr = self.v_generation[gen, period, t] <= (profile_value * cap)
             else:

--- a/src/powergim/testcases.py
+++ b/src/powergim/testcases.py
@@ -70,6 +70,7 @@ def create_case(investment_years, number_nodes, number_timesteps, base_MW=200):
     generators["pavg"] = 0
     generators["inflow_fac"] = 1
     generators["inflow_ref"] = "inflow_" + generators["type"]
+    generators["allow_curtailment"] = 1
 
     timesteps = np.array(range(number_timesteps))
     profiles = pd.DataFrame(index=timesteps)
@@ -117,12 +118,10 @@ def create_case(investment_years, number_nodes, number_timesteps, base_MW=200):
             "gentype0": {
                 "CX": 0,
                 "CO2": 0,
-                "allow_curtailment": True,
             },
             "gentype1": {
                 "CX": 100,
                 "CO2": 0,
-                "allow_curtailment": True,
             },
         },
         "parameters": {
@@ -217,6 +216,7 @@ def create_case_star(investment_years, number_nodes, number_timesteps, base_MW=2
     generators["pavg"] = 0
     generators["inflow_fac"] = 1
     generators["inflow_ref"] = "inflow_" + generators["type"]
+    generators["allow_curtailment"] = 1
 
     timesteps = np.array(range(number_timesteps))
     profiles = pd.DataFrame(index=timesteps)
@@ -264,12 +264,10 @@ def create_case_star(investment_years, number_nodes, number_timesteps, base_MW=2
             "gentype0": {
                 "CX": 0,
                 "CO2": 0,
-                "allow_curtailment": True,
             },
             "gentype1": {
                 "CX": 100,
                 "CO2": 0,
-                "allow_curtailment": True,
             },
         },
         "parameters": {

--- a/tests/stochastic/data/generators.csv
+++ b/tests/stochastic/data/generators.csv
@@ -1,7 +1,7 @@
-desc,type,node,capacity_2025,capacity_2028,pmin,fuelcost,fuelcost_ref,pavg,inflow_fac,inflow_ref,expand_2025,expand_2028,cost_scaling,p_maxNew,storage_cap,storage_price,storage_ini,storval_filling_ref,storval_time_ref,pump_cap,pump_efficiency,pump_deadband
-UK,alt,UK_main,100000,0,0,1,UK,0,1,const,0,0,1,0,0,,,,,,,
-NO,alt,NO_main,100000,0,0,1,NO2,0,1,const,0,0,1,0,0,,,,,,,
-DK hub wind,alt,DK_main,100000,0,0,1,DK1,0,1,const,0,0,1,0,0,,,,,,,
-UK dog,wind,UK_dog,2400,7000,0,0,const,0,1,wind_0.45,0,0,1,0,0,,,,,,,
-NO_SN,wind,NO_SN,1400,7000,0,0,const,0,1,wind_0.45,0,0,1,0,0,,,,,,,
-DK hub wind,wind,DK_hub,3000,7000,0,0,const,0,1,wind_0.45,0,0,1,0,0,,,,,,,
+desc,type,node,capacity_2025,capacity_2028,pmin,allow_curtailment,fuelcost,fuelcost_ref,pavg,inflow_fac,inflow_ref,expand_2025,expand_2028,cost_scaling,p_maxNew,storage_cap,storage_price,storage_ini,storval_filling_ref,storval_time_ref,pump_cap,pump_efficiency,pump_deadband
+UK,alt,UK_main,100000,0,0,1,1,UK,0,1,const,0,0,1,0,0,,,,,,,
+NO,alt,NO_main,100000,0,0,1,1,NO2,0,1,const,0,0,1,0,0,,,,,,,
+DK hub wind,alt,DK_main,100000,0,0,1,1,DK1,0,1,const,0,0,1,0,0,,,,,,,
+UK dog,wind,UK_dog,2400,7000,0,0,0,const,0,1,wind_0.45,0,0,1,0,0,,,,,,,
+NO_SN,wind,NO_SN,1400,7000,0,0,0,const,0,1,wind_0.45,0,0,1,0,0,,,,,,,
+DK hub wind,wind,DK_hub,3000,7000,0,0,0,const,0,1,wind_0.45,0,0,1,0,0,,,,,,,

--- a/tests/stochastic/data/parameters_stoch.yaml
+++ b/tests/stochastic/data/parameters_stoch.yaml
@@ -61,12 +61,9 @@ gentype:
     alt:
         CX: 10
         CO2: 0
-        allow_curtailment: true
     wind:
         CX: 0
         CO2: 0
-        allow_curtailment: false # TODO: disallowing curtailment gives trouble - solves but returns None variable values
-    #    curtailment_cost: 0
 parameters:
     investment_years: [2025, 2028]
     finance_interest_rate: 0.05

--- a/tests/test_data/generators.csv
+++ b/tests/test_data/generators.csv
@@ -1,7 +1,7 @@
-desc,type,node,capacity_2025,capacity_2028,expand_2025,expand_2028,pmin,fuelcost,fuelcost_ref,pavg,inflow_fac,inflow_ref,cost_scaling,p_maxNew,storage_cap,storage_price,storage_ini,storval_filling_ref,storval_time_ref,pump_cap,pump_efficiency,pump_deadband
-UK,alt,UK_main,100000,0,0,0,0,1,UK,0,1,const,1,0,0,,,,,,,
-NO,alt,NO_main,100000,0,0,0,0,1,NO2,0,1,const,1,0,0,,,,,,,
-DK hub wind,alt,DK_main,100000,0,0,0,0,1,DK1,0,1,const,1,0,0,,,,,,,
-UK dog,wind,UK_dog,6000,0,0,0,0,0,const,0,1,wind_0.45,1,0,0,,,,,,,
-NO_SN,wind,NO_SN,1000,5000,0,0,0,0,const,0,1,wind_0.45,1,0,0,,,,,,,
-DK hub wind,wind,DK_hub,1000,5000,0,0,0,0,const,0,1,wind_0.45,1,0,0,,,,,,,
+desc,type,node,capacity_2025,capacity_2028,expand_2025,expand_2028,pmin,allow_curtailment,fuelcost,fuelcost_ref,pavg,inflow_fac,inflow_ref,cost_scaling,p_maxNew,storage_cap,storage_price,storage_ini,storval_filling_ref,storval_time_ref,pump_cap,pump_efficiency,pump_deadband
+UK,alt,UK_main,100000,0,0,0,0,1,1,UK,0,1,const,1,0,0,,,,,,,
+NO,alt,NO_main,100000,0,0,0,0,1,1,NO2,0,1,const,1,0,0,,,,,,,
+DK hub wind,alt,DK_main,100000,0,0,0,0,1,1,DK1,0,1,const,1,0,0,,,,,,,
+UK dog,wind,UK_dog,6000,0,0,0,0,0,0,const,0,1,wind_0.45,1,0,0,,,,,,,
+NO_SN,wind,NO_SN,1000,5000,0,0,0,0,0,const,0,1,wind_0.45,1,0,0,,,,,,,
+DK hub wind,wind,DK_hub,1000,5000,0,0,0,0,0,const,0,1,wind_0.45,1,0,0,,,,,,,

--- a/tests/test_data/parameters.yaml
+++ b/tests/test_data/parameters.yaml
@@ -61,12 +61,9 @@ gentype:
     alt:
         CX: 10
         CO2: 0
-        allow_curtailment: true
     wind:
         CX: 0
         CO2: 0
-        allow_curtailment: false # TODO: disallowing curtailment gives trouble - solves but returns None variable values
-    #    curtailment_cost: 0
 parameters:
     investment_years: [2025, 2028]
     finance_interest_rate: 0.05


### PR DESCRIPTION
Change so option to allow curtailment is specified per generator in generator input data instead of per generator type

Why
- More flexible, allows to force investments
- Useful for debugging models

How
- Remove `allow_curtailment`option in parameter input yaml file
- Add column in generator input (csv data)

Closes
- #10 