### PR TITLE
fix double-discounting of o&m costs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 - Model creation speedup
 - Fix bug when extracting grid results
 - Change in emission cap implementation
+- Fix bug in net present value calculation
 
 ## v0.4.0
 2023-03-10 - First release of development version

--- a/src/powergim/investment_model.py
+++ b/src/powergim/investment_model.py
@@ -549,8 +549,9 @@ class SipModel(pyo.ConcreteModel):
             # Remaining value of investment at end of period considered (self.finance_years)
             # if delta_years=0, then residual value should be zero.
             # if delta_years=finance_years, then residual value factor should be 1
+            # NPV value at time 0
             residual_factor = (delta_years / self.finance_years) * (
-                1 / ((1 + self.finance_interest_rate) ** (self.finance_years - delta_years))
+                1 / ((1 + self.finance_interest_rate) ** self.finance_years)
             )
         if include_om:
             # NPV of all O&M from investment made to end of time period considered
@@ -563,8 +564,7 @@ class SipModel(pyo.ConcreteModel):
         # present value vs future value: pv = fv/(1+r)^n
         discount_t0 = 1 / ((1 + self.finance_interest_rate) ** (delta_years))
 
-        investment = investment * discount_t0
-        pv_cost = investment * (1 + om_factor - residual_factor)
+        pv_cost = investment * (discount_t0 + om_factor - residual_factor)
         return pv_cost
 
     def costInvestments(self, period, include_om=True, subtract_residual_value=True):

--- a/src/powergim/investment_model.py
+++ b/src/powergim/investment_model.py
@@ -240,7 +240,7 @@ class SipModel(pyo.ConcreteModel):
             previous_periods = [p for p in self.s_period if p <= period]
             for p in previous_periods:
                 branch_existing_capacity += self.grid_data.branch.at[branch, f"capacity_{p}"]
-                if self.grid_data.branch.at[branch, f"expand_{period}"] == 1:
+                if self.grid_data.branch.at[branch, f"expand_{p}"] == 1:
                     branch_new_capacity += self.v_branch_new_capacity[branch, p]
             return branch_existing_capacity + branch_new_capacity
 

--- a/tests/stochastic/test_stochastic.py
+++ b/tests/stochastic/test_stochastic.py
@@ -61,9 +61,7 @@ def test_stochastic_ef():
     # sputils.ef_ROOT_nonants_npy_serializer(main_ef, "sns_root_nonants.npy")
     print(f"EF objective: {pyo.value(main_ef.EF_Obj)}")
 
-    assert pyo.value(main_ef.EF_Obj) == pytest.approx(131457566096)
-    # assert all_var_values["scen2.opCost"][1] == pytest.approx(2.0442991e10)
-    # assert all_var_values["scen2.opCost"][2] == pytest.approx(5.3318421e10)
+    assert pyo.value(main_ef.EF_Obj) == pytest.approx(133.10901e9)
 
 
 @pytest.mark.skipif(not pyo.SolverFactory("glpk").available(), reason="Skipping test because GLPK is not available.")

--- a/tests/stochastic/test_stochastic_star.py
+++ b/tests/stochastic/test_stochastic_star.py
@@ -12,10 +12,10 @@ def test_stochastic_star_ef():
     main_ef, all_var_values = starcase.solve_ef("cbc", solver_io="nl")
 
     print(f"EF objective: {pyo.value(main_ef.EF_Obj)}")
-    assert pyo.value(main_ef.EF_Obj) == pytest.approx(116.423807785e9)
-    assert all_var_values["scen0"]["OBJ"] == pytest.approx(117.259360900e9)
+    assert pyo.value(main_ef.EF_Obj) == pytest.approx(117.84348e9)
+    assert all_var_values["scen0"]["OBJ"] == pytest.approx(118.38123e9)
     assert all_var_values["scen0"]["scen0.v_investment_cost"][0] == pytest.approx(16.46419e9)
-    assert all_var_values["scen0"]["scen0.v_investment_cost"][10] == pytest.approx(5.345655e9)
+    assert all_var_values["scen0"]["scen0.v_investment_cost"][10] == pytest.approx(6.46752e9)
 
 
 # TODO: Understand why this test fails (but not glpk, or mpi ones)

--- a/tests/test_deterministic.py
+++ b/tests/test_deterministic.py
@@ -12,7 +12,6 @@ NUMERIC_THRESHOLD = 1e-3
 
 @pytest.mark.skipif(not pyo.SolverFactory("glpk").available(), reason="Skipping test because GLPK is not available.")
 def test_deterministic():
-
     # Read input data
     parameter_data = pgim.file_io.read_parameters(TEST_DATA_ROOT_PATH / "parameters.yaml")
     grid_data = pgim.file_io.read_grid(
@@ -47,10 +46,10 @@ def test_deterministic():
 
     # Check results are as expected
     print(f"Objective = {pyo.value(sip.OBJ)}")
-    print(all_var_values.keys())
-
-    assert all_var_values["v_investment_cost"][2025] == pytest.approx(18.541664000e9)
-    assert all_var_values["v_investment_cost"][2028] == pytest.approx(25.829794000e9)
+    # print(all_var_values.keys())
+    assert pyo.value(sip.OBJ) == pytest.approx(15189.51e9)
+    assert all_var_values["v_investment_cost"][2025] == pytest.approx(18.54166e9)
+    assert all_var_values["v_investment_cost"][2028] == pytest.approx(27.54888e9)
 
     expected_branch_new_capacity = pd.read_csv(
         TEST_DATA_ROOT_PATH / "expected_branch_new_capacity.csv", index_col=["s_branch", "s_period"]

--- a/tests/test_test1.py
+++ b/tests/test_test1.py
@@ -22,12 +22,12 @@ def test_case_N5():
     assert pyo.check_optimal_termination(results)
 
     # print(pyo.value(sip.OBJ))
-    assert pyo.value(sip.OBJ) == pytest.approx(181.7401e9)
+    assert pyo.value(sip.OBJ) == pytest.approx(183.2714e9)
 
     # Optimal variable values
     all_var_values = sip.extract_all_variable_values()
     assert all_var_values["v_new_nodes"].sum() == 5
-    print(all_var_values["v_branch_new_capacity"][4])
+    # print(all_var_values["v_branch_new_capacity"][4])
     assert all_var_values["v_branch_new_capacity"][4][0] == pytest.approx(0)
     assert all_var_values["v_branch_new_capacity"][4][10] == pytest.approx(3000)
     assert all_var_values["v_branch_new_capacity"][4][20] == pytest.approx(3000)
@@ -51,14 +51,14 @@ def test_case_N4():
     assert pyo.check_optimal_termination(results)
 
     # print(pyo.value(sip.OBJ))
-    assert pyo.value(sip.OBJ) == pytest.approx(113.77779e9)
+    assert pyo.value(sip.OBJ) == pytest.approx(114.7293e9)
 
     # Optimal variable values
     all_var_values = sip.extract_all_variable_values()
-    assert all_var_values["v_new_nodes"].sum() == 3
-    assert all_var_values["v_branch_new_capacity"].sum() == 7000
+    assert all_var_values["v_new_nodes"].sum() == 4
+    assert all_var_values["v_branch_new_capacity"].sum() == 9000
     assert (all_var_values["v_branch_flow12"][0][0] == 0).all()
-    assert (all_var_values["v_branch_flow12"][0][10] == 3000).all()
+    assert (all_var_values["v_branch_flow12"][3][10] == 3000).all()
     assert (all_var_values["v_load_shed"] == 0).all()
 
 


### PR DESCRIPTION
# Pull Request

### WHAT

Change in the computation of net present value of investment costs in optimisation model.
NOTE! This changes the optimisation results.

### WHY

The O&M costs in present implementation is discounted twice

### HOW

Update expression in definition of [npvInvestment](https://github.com/powergama/powergim/blob/beedd5e62f180120c493266ac8e94b046172b70d/src/powergim/investment_model.py#L533)

present:
```
if subtract_residual_value:
    residual_factor = (delta_years / self.finance_years) * (
        1 / ((1 + self.finance_interest_rate) ** (self.finance_years - delta_years))
    )
if include_om:
    # NPV of all O&M from investment made to end of time period considered
    om_factor = self.operation_maintenance_rate * (
        annuityfactor(self.finance_interest_rate, self.finance_years)
        - annuityfactor(self.finance_interest_rate, delta_years)
    )
investment = investment * discount_t0  
pv_cost = investment * (1 + om_factor - residual_factor)
```
proposal:
```
if subtract_residual_value:
    residual_factor = (delta_years / self.finance_years) * (
        1 / ((1 + self.finance_interest_rate) ** self.finance_years)
    )
if include_om:
    # NPV of all O&M from investment made to end of time period considered
    om_factor = self.operation_maintenance_rate * (
        annuityfactor(self.finance_interest_rate, self.finance_years)
        - annuityfactor(self.finance_interest_rate, delta_years)
    )
pv_cost = investment * (discount_t0 + om_factor - residual_factor)
```

**Residual value**: First, compute residual value at end of period (t=finance_years). Then discount this back to the present (t=0). For an investment made at delta_years=finance_years => residual_factor=1.0. But this residual value is discounted in the same way as the capital expense. But in general, discounted from the end of horizon (finance_years) rather than from the point of investments (delta_years).
The expression for residual value is correct also at present - it is discounted in two steps. First back to the investment time, then back to present. However, the new expression is simpler, doing this in a single step.

**OM costs**: These are costs _every year_ from the point of investment to the end. These are already discounted via the annuityfactor in the expression for the om_factor. I.e. no futher discounting should be done. This is where a correction is needed.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix - Requires bug fix version bump. e.g. from v1.0.0 to v1.0.1

## What to test/verify

This affects the optimisation objective value and therefore most of the tests.

## Checklist:

- [x] :tada: This PR closes #31 .
- [x] :robot: I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR.
- [x] :book: I have considered adding a new entry in `CHANGES.md`.


