### PR TITLE
change so fuelcost is specified separately for each operating period

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 # Changes
 
+## v0.5.0
+- Change input data format for generator fuel costs
+
 ## v0.4.1
 - Change input data format for nodes and consumers
 - Model creation speedup

--- a/docs/powergim.md
+++ b/docs/powergim.md
@@ -109,8 +109,8 @@ column | description | type | units
 -------|-------------|------|------
 id   | Unique string identifier | string
 area | Area/country code | string
-capacity_\<year\>  | (Additional) capacity installed before investment year <year>| float   | MW
-expand_\<year\>    | Consider expansion in investment year <year>   | boolean | 0,1
+capacity_\<year\>  | (Additional) capacity installed before investment year \<year\>| float   | MW
+expand_\<year\>    | Consider expansion in investment year \<year\>   | boolean | 0,1
 lat  | Latitude   | float |degrees
 lon  | Longitude  | float |degrees
 offshore | Whether node is offshore | boolean | 0,1
@@ -125,8 +125,8 @@ column | description | type | units
 -------|-------------|------|------
 node_from | Node identifier | string
 node to   | Node identifier | string
-capacity_\<year\>  | (Additional) capacity installed before investment year <year>| float   | MW
-expand_\<year\>    | Consider expansion in investment year <year>   | boolean | 0,1
+capacity_\<year\>  | (Additional) capacity installed before investment year \<year\>| float   | MW
+expand_\<year\>    | Consider expansion in investment year \<year\>   | boolean | 0,1
 distance  | Branch length (OPT) | float | km
 max_newCap    | Max new capacity (OPT) | float | km
 cost_scaling  | Cost scaling factor | float
@@ -152,11 +152,11 @@ column | description | type | units
 node  | Node identifier |string
 desc  | Description or name (OPT) |string
 type  | Generator type |string
-capacity_\<year\>  | (Additional) capacity installed before investment year <year>  |float |MW
+capacity_\<year\>  | (Additional) capacity installed before investment year \<year\>  |float |MW
 pmin  | Minimum production |float |MW
-expand_\<year\> | Consider expansion in investment year <year>   | boolean | 0,1
+expand_\<year\> | Consider expansion in investment year \<year\>   | boolean | 0,1
 allow_curtailment | Whether generator can be curtailed | boolean | 0,1
-fuelcost  | Cost of generation |float |€/MWh
+fuelcost_\<year\>  | Cost of generation in operating period \<year\> |float |€/MWh
 fuelcost_ref  | Cost profile |string
 inflow_fac  | Inflow factor |float
 inflow_ref  | Inflow profile reference |string

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "powergim"
-version = "0.4.1"
+version = "0.5.0"
 description = "Power Grid Investment Module (PowerGIM)"
 authors = ["Harald G Svendsen <harald.svendsen@sintef.no>"]
 license = "MIT License (http://opensource.org/licenses/MIT)"

--- a/src/powergim/grid_data.py
+++ b/src/powergim/grid_data.py
@@ -55,7 +55,7 @@ class GridData(object):
                 "allow_curtailment": None,
                 "p_maxNew": -1,
                 "cost_scaling": 1,
-                "fuelcost": None,
+                **{f"fuelcost_{p}": None for p in self.investment_years},
                 "fuelcost_ref": None,
                 "pavg": 0,
                 "inflow_fac": None,

--- a/src/powergim/investment_model.py
+++ b/src/powergim/investment_model.py
@@ -590,7 +590,7 @@ class SipModel(pyo.ConcreteModel):
         # operation cost for single year:
         opcost = 0
         for gen in self.s_gen:
-            fuelcost = self.grid_data.generator.at[gen, "fuelcost"]
+            fuelcost = self.grid_data.generator.at[gen, f"fuelcost_{period}"]
             cost_profile_ref = self.grid_data.generator.at[gen, "fuelcost_ref"]
             if self.parameters["profiles_period_suffix"]:
                 cost_profile_ref = f"{cost_profile_ref}_{period}"
@@ -627,7 +627,7 @@ class SipModel(pyo.ConcreteModel):
     def costOperationSingleGen(self, gen, period):
         """Operational costs: cost of gen, load shed (NPV)"""
 
-        fuelcost = self.grid_data.generator.at[gen, "fuelcost"]
+        fuelcost = self.grid_data.generator.at[gen, f"fuelcost_{period}"]
         cost_profile_ref = self.grid_data.generator.at[gen, "fuelcost_ref"]
         if self.parameters["profiles_period_suffix"]:
             cost_profile_ref = f"{cost_profile_ref}_{period}"

--- a/src/powergim/testcases.py
+++ b/src/powergim/testcases.py
@@ -70,7 +70,8 @@ def create_case(investment_years, number_nodes, number_timesteps, base_MW=200):
 
     generators["pmin"] = 0
     generators["cost_scaling"] = 1
-    generators["fuelcost"] = [10 * (i % 2) for i in range(generators.shape[0])] + generators.index / 2
+    for year in investment_years:
+        generators[f"fuelcost_{year}"] = [10 * (i % 2) for i in range(generators.shape[0])] + generators.index / 2
     generators["fuelcost_ref"] = "fuelcost_" + generators["type"]
     generators["pavg"] = 0
     generators["inflow_fac"] = 1
@@ -222,8 +223,9 @@ def create_case_star(investment_years, number_nodes, number_timesteps, base_MW=2
         )
     generators["pmin"] = 0
     generators["cost_scaling"] = 1
-    generators["fuelcost"] = 0
-    generators.loc[generators["type"] == "gentype1", "fuelcost"] = 100
+    for year in investment_years:
+        generators[f"fuelcost_{year}"] = 0
+        generators.loc[generators["type"] == "gentype1", f"fuelcost_{year}"] = 100
     generators["fuelcost_ref"] = "fuelcost_" + generators["type"]
     generators["pavg"] = 0
     generators["inflow_fac"] = 1

--- a/tests/stochastic/data/generators.csv
+++ b/tests/stochastic/data/generators.csv
@@ -1,7 +1,7 @@
-desc,type,node,capacity_2025,capacity_2028,pmin,allow_curtailment,fuelcost,fuelcost_ref,pavg,inflow_fac,inflow_ref,expand_2025,expand_2028,cost_scaling,p_maxNew,storage_cap,storage_price,storage_ini,storval_filling_ref,storval_time_ref,pump_cap,pump_efficiency,pump_deadband
-UK,alt,UK_main,100000,0,0,1,1,UK,0,1,const,0,0,1,0,0,,,,,,,
-NO,alt,NO_main,100000,0,0,1,1,NO2,0,1,const,0,0,1,0,0,,,,,,,
-DK hub wind,alt,DK_main,100000,0,0,1,1,DK1,0,1,const,0,0,1,0,0,,,,,,,
-UK dog,wind,UK_dog,2400,7000,0,0,0,const,0,1,wind_0.45,0,0,1,0,0,,,,,,,
-NO_SN,wind,NO_SN,1400,7000,0,0,0,const,0,1,wind_0.45,0,0,1,0,0,,,,,,,
-DK hub wind,wind,DK_hub,3000,7000,0,0,0,const,0,1,wind_0.45,0,0,1,0,0,,,,,,,
+desc,type,node,capacity_2025,capacity_2028,pmin,allow_curtailment,fuelcost_2025,fuelcost_2028,fuelcost_ref,pavg,inflow_fac,inflow_ref,expand_2025,expand_2028,cost_scaling,p_maxNew
+UK,alt,UK_main,100000,0,0,1,1,1,UK,0,1,const,0,0,1,0
+NO,alt,NO_main,100000,0,0,1,1,1,NO2,0,1,const,0,0,1,0
+DK hub wind,alt,DK_main,100000,0,0,1,1,1,DK1,0,1,const,0,0,1,0
+UK dog,wind,UK_dog,2400,7000,0,0,0,0,const,0,1,wind_0.45,0,0,1,0
+NO_SN,wind,NO_SN,1400,7000,0,0,0,0,const,0,1,wind_0.45,0,0,1,0
+DK hub wind,wind,DK_hub,3000,7000,0,0,0,0,const,0,1,wind_0.45,0,0,1,0

--- a/tests/test_data/generators.csv
+++ b/tests/test_data/generators.csv
@@ -1,7 +1,7 @@
-desc,type,node,capacity_2025,capacity_2028,expand_2025,expand_2028,pmin,allow_curtailment,fuelcost,fuelcost_ref,pavg,inflow_fac,inflow_ref,cost_scaling,p_maxNew,storage_cap,storage_price,storage_ini,storval_filling_ref,storval_time_ref,pump_cap,pump_efficiency,pump_deadband
-UK,alt,UK_main,100000,0,0,0,0,1,1,UK,0,1,const,1,0,0,,,,,,,
-NO,alt,NO_main,100000,0,0,0,0,1,1,NO2,0,1,const,1,0,0,,,,,,,
-DK hub wind,alt,DK_main,100000,0,0,0,0,1,1,DK1,0,1,const,1,0,0,,,,,,,
-UK dog,wind,UK_dog,6000,0,0,0,0,0,0,const,0,1,wind_0.45,1,0,0,,,,,,,
-NO_SN,wind,NO_SN,1000,5000,0,0,0,0,0,const,0,1,wind_0.45,1,0,0,,,,,,,
-DK hub wind,wind,DK_hub,1000,5000,0,0,0,0,0,const,0,1,wind_0.45,1,0,0,,,,,,,
+desc,type,node,capacity_2025,capacity_2028,expand_2025,expand_2028,pmin,allow_curtailment,fuelcost_2025,fuelcost_2028,fuelcost_ref,pavg,inflow_fac,inflow_ref,cost_scaling,p_maxNew
+UK,alt,UK_main,100000,0,0,0,0,1,1,1,UK,0,1,const,1,0
+NO,alt,NO_main,100000,0,0,0,0,1,1,1,NO2,0,1,const,1,0
+DK hub wind,alt,DK_main,100000,0,0,0,0,1,1,1,DK1,0,1,const,1,0
+UK dog,wind,UK_dog,6000,0,0,0,0,0,0,0,const,0,1,wind_0.45,1,0
+NO_SN,wind,NO_SN,1000,5000,0,0,0,0,0,0,const,0,1,wind_0.45,1,0
+DK hub wind,wind,DK_hub,1000,5000,0,0,0,0,0,0,const,0,1,wind_0.45,1,0


### PR DESCRIPTION
# Pull Request

### WHAT

Change so fuelcost is specified separately for each investment period.
Changes input format

### WHY

Marginal costs for thermal power plants depends on CO2 tax that is likely to increase , changing the relative costs. 

### HOW

Change generator input csv file colum `fuelcost` to multiple columns `fuelcost_<year>` where `<year>` are the operating periods. This is the same format as already done for generator capacities.

## Type of change

Please delete options that are not relevant.

- [x] New feature - Requires minor version bump. e.g. form v1.1.0 to v1.2.0
- [x] Breaking change - Requires major version bump. e.g. from v1.*.* to v2.0.0
- [x] Requires documentation

## What to test/verify

Updated documentation

## Checklist:

- [x] :tada: This PR closes #33 .
- [x] :robot: I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR.
- [x] :book: I have considered adding a new entry in `CHANGES.md`.
- [x] :books: I have considered updating the documentation in `README.md`.
